### PR TITLE
Use `isfinite` function for ARM compatibility

### DIFF
--- a/src/admutils.c
+++ b/src/admutils.c
@@ -456,7 +456,7 @@ testnan(double *a, int n)
   int i ;
 
   for (i=0; i<n; i++) {
-   if (!finite(a[i])) fatalx("(testnan) fails:  index %d\n",i) ;
+   if (!isfinite(a[i])) fatalx("(testnan) fails:  index %d\n",i) ;
   }
 }
 void getgall(SNP *cupt, int *x, int n) 


### PR DESCRIPTION
The `finite` function doesn't exist on ARM architectures.

```
admutils.c:459:9: error: call to undeclared library function 'finite' with type 'int (double)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   if (!finite(a[i])) fatalx("(testnan) fails:  index %d\n",i) ;
        ^
admutils.c:459:9: note: include the header <math.h> or explicitly provide a declaration for 'finite'
1 error generated.
make: *** [admutils.o] Error 1
```